### PR TITLE
Enforce no grouping in currency formatter, to be consistent with MoneyFilter. Fixes #13922

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/subscription/boost/Boost.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/subscription/boost/Boost.kt
@@ -291,6 +291,7 @@ data class Boost(
         }
 
         formatter.maximumFractionDigits = currency.defaultFractionDigits
+        formatter.isGroupingUsed = false
 
         val value = s.toString().toDoubleOrNull()
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual device W, Android 15.0
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
The grouping separator character (e.g. 1,000 vs 1000) was being inserted when pasting into the custom donations field, unexpectedly. This formatting needed to be removed, so the value could be easily edited after pasting. 

With USA Locale, pasted "12345" into the custom donation field and saw it formatted as "$12,345"
Before fix, you could not delete any digits until after the comma was deleted. NumberFormatException was being caught in the withoutLeadingZeroes code.

After fix, saw it was formatted as "$12345"  and digits could be deleted as expected. NumberFormatException was no longer being generated.

Also tested with 
Thoughtcrime
$12,345
12345
12,345
$12,345.00
12,345.00
12345.00
$0012345
$0012,345
532&12345
1,23
0012345
0012345.00
0012345.00$
as well as typing in 12345

text cannot be pasted with unexpected characters, and seems to format consistently now
-->
